### PR TITLE
Replace numbered list with headings, restore two missing images

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,39 +22,39 @@ visualkeras.layered_view(model)
 
 3. [**draw_convnet**](https://github.com/gwding/draw_convnet) : Python script for illustrating Convolutional Neural Network (ConvNet)
 
- ![img](https://raw.githubusercontent.com/gwding/draw_convnet/master/convnet_fig.png) 
+ ![img](https://raw.githubusercontent.com/gwding/draw_convnet/master/convnet_fig.png)
 
 4. [**NNSVG**](http://alexlenail.me/NN-SVG/LeNet.html)
 
- ![AlexNet style](https://i.stack.imgur.com/Q0xOe.png) 
+ ![AlexNet style](https://i.stack.imgur.com/Q0xOe.png)
 
- ![enter image description here](https://i.stack.imgur.com/K9lmg.png) 
+ ![enter image description here](https://i.stack.imgur.com/K9lmg.png)
 
- ![enter image description here](https://i.stack.imgur.com/DlJ8J.png) 
+ ![enter image description here](https://i.stack.imgur.com/DlJ8J.png)
 
-5. **[PlotNeuralNet](https://github.com/HarisIqbal88/PlotNeuralNet)**  : Latex code for drawing neural networks for reports and presentation. Have a look into examples to see how they are made. Additionally, lets consolidate any improvements that you make and fix any bugs to help more people with this code. 
+5. **[PlotNeuralNet](https://github.com/HarisIqbal88/PlotNeuralNet)**  : Latex code for drawing neural networks for reports and presentation. Have a look into examples to see how they are made. Additionally, lets consolidate any improvements that you make and fix any bugs to help more people with this code.
 
- ![img](https://user-images.githubusercontent.com/17570785/50308846-c2231880-049c-11e9-8763-3daa1024de78.png) 
+ ![img](https://user-images.githubusercontent.com/17570785/50308846-c2231880-049c-11e9-8763-3daa1024de78.png)
 
- ![img](https://user-images.githubusercontent.com/17570785/50308873-e2eb6e00-049c-11e9-9587-9da6bdec011b.png) 
+ ![img](https://user-images.githubusercontent.com/17570785/50308873-e2eb6e00-049c-11e9-9587-9da6bdec011b.png)
 
-6. **[Tensorboard](https://www.tensorflow.org/tensorboard/graphs)** -  TensorBoard’s **Graphs dashboard** is a powerful tool for examining your TensorFlow model. 
+6. **[Tensorboard](https://www.tensorflow.org/tensorboard/graphs)** -  TensorBoard’s **Graphs dashboard** is a powerful tool for examining your TensorFlow model.
 
- ![enter image description here](https://i.stack.imgur.com/zJHpV.png) 
+ ![enter image description here](https://i.stack.imgur.com/zJHpV.png)
 
-7. **[Caffe](https://github.com/BVLC/caffe/blob/master/python/caffe/draw.py)** -  In Caffe you can use [caffe/draw.py](https://github.com/BVLC/caffe/blob/master/python/caffe/draw.py) to draw the NetParameter protobuffer: 
+7. **[Caffe](https://github.com/BVLC/caffe/blob/master/python/caffe/draw.py)** -  In Caffe you can use [caffe/draw.py](https://github.com/BVLC/caffe/blob/master/python/caffe/draw.py) to draw the NetParameter protobuffer:
 
- ![enter image description here](https://i.stack.imgur.com/5Z1Cb.png) 
+ ![enter image description here](https://i.stack.imgur.com/5Z1Cb.png)
 
 8. **[Matlab](http://www.mathworks.com/help/nnet/ref/view.html)**
 
- ![enter image description here](https://i.stack.imgur.com/rPpfa.png) 
+ ![enter image description here](https://i.stack.imgur.com/rPpfa.png)
 
 9. [**Keras.js**](https://transcranial.github.io/keras-js/#/inception-v3)
 
- ![enter image description here](https://i.stack.imgur.com/vEfTv.png) 
+ ![enter image description here](https://i.stack.imgur.com/vEfTv.png)
 
-9. **[keras-sequential-ascii](https://github.com/stared/keras-sequential-ascii/)** -  A library for [Keras](https://keras.io/) for investigating architectures and parameters of sequential models. 
+9. **[keras-sequential-ascii](https://github.com/stared/keras-sequential-ascii/)** -  A library for [Keras](https://keras.io/) for investigating architectures and parameters of sequential models.
 
 **VGG 16 Architecture**
 
@@ -110,29 +110,29 @@ visualkeras.layered_view(model)
             softmax   #####        1000
 ```
 
-10. **[ Netron ](https://github.com/lutzroeder/Netron)**
+10. **[Netron](https://github.com/lutzroeder/Netron)**
 
- ![screenshot.png](https://github.com/lutzroeder/netron/raw/main/.github/screenshot.png) 
+ ![screenshot.png](https://github.com/lutzroeder/netron/raw/main/.github/screenshot.png)
 
 11. **[DotNet](https://github.com/martisak/dotnets)**
 
- ![Simple net](https://github.com/martisak/dotnets/raw/master/test.png) 
+ ![Simple net](https://github.com/martisak/dotnets/raw/master/test.png)
 
 12. [**Graphviz**](http://www.graphviz.org/) : **[Tutorial](https://tgmstat.wordpress.com/2013/06/12/draw-neural-network-diagrams-graphviz/)**
 
- ![img](https://tgmstat.files.wordpress.com/2013/05/multiclass_neural_network_example.png) 
+ ![img](https://tgmstat.files.wordpress.com/2013/05/multiclass_neural_network_example.png)
 
-13. **[Keras Visualization](https://keras.io/visualization/)** -  The [keras.utils.vis_utils module](https://keras.io/visualization/) provides utility functions to plot a Keras model (using graphviz) 
+13. **[Keras Visualization](https://keras.io/visualization/)** -  The [keras.utils.vis_utils module](https://keras.io/visualization/) provides utility functions to plot a Keras model (using graphviz)
 
- ![enter image description here](https://i.stack.imgur.com/o17GY.png) 
+ ![enter image description here](https://i.stack.imgur.com/o17GY.png)
 
-14. **[Conx](https://conx.readthedocs.io/en/latest/index.html)** -  The Python package `conx` can visualize networks with activations with the function `net.picture()` to produce SVG, PNG, or PIL Images like this: 
+14. **[Conx](https://conx.readthedocs.io/en/latest/index.html)** -  The Python package `conx` can visualize networks with activations with the function `net.picture()` to produce SVG, PNG, or PIL Images like this:
 
- ![enter image description here](https://i.stack.imgur.com/nhHjO.png) 
+ ![enter image description here](https://i.stack.imgur.com/nhHjO.png)
 
-15. **[ENNUI](https://math.mit.edu/ennui/)** -  Working on a drag-and-drop neural network visualizer (and more). Here's an example of a visualization for a LeNet-like architecture. 
+15. **[ENNUI](https://math.mit.edu/ennui/)** -  Working on a drag-and-drop neural network visualizer (and more). Here's an example of a visualization for a LeNet-like architecture.
 
- ![A visualization of a LeNet-like architecture](https://i.stack.imgur.com/pRLeG.png) 
+ ![A visualization of a LeNet-like architecture](https://i.stack.imgur.com/pRLeG.png)
 
 16. **NNet - R Package** - **[Tutorial](https://beckmw.wordpress.com/2013/03/04/visualizing-neural-networks-from-the-nnet-package/)**
 
@@ -143,42 +143,41 @@ plot(neuralnet(case~parity+induced+spontaneous, infert))
 
 [![neuralnet](https://i.stack.imgur.com/yyftd.png)](https://
 
-17. **[GraphCore](https://www.graphcore.ai/posts/what-does-machine-learning-look-like)** -  These approaches are more oriented towards visualizing neural network operation, however, NN architecture is also somewhat visible on the resulting diagrams. 
+17. **[GraphCore](https://www.graphcore.ai/posts/what-does-machine-learning-look-like)** -  These approaches are more oriented towards visualizing neural network operation, however, NN architecture is also somewhat visible on the resulting diagrams.
 
 **AlexNet**
 
- ![alexnet_label logo.jpg](https://www.graphcore.ai/hubfs/images/alexnet_label%20logo.jpg) 
+ ![alexnet_label logo.jpg](https://www.graphcore.ai/hubfs/images/alexnet_label%20logo.jpg)
 
  **ResNet50**![resnet50_label_logo.jpg](https://www.graphcore.ai/hubfs/images/resnet50_label_logo.jpg)
 
-18.  [**Neataptic**](https://wagenaartje.github.io/neataptic/ )
+18. [**Neataptic**](https://wagenaartje.github.io/neataptic/ )
 
-Neataptic offers flexible neural networks; neurons and synapses can be removed with a single line of code. No fixed architecture is required for neural networks to function at all. This flexibility allows networks to be shaped for your dataset through neuro-evolution, which is done using multiple threads. 
+Neataptic offers flexible neural networks; neurons and synapses can be removed with a single line of code. No fixed architecture is required for neural networks to function at all. This flexibility allows networks to be shaped for your dataset through neuro-evolution, which is done using multiple threads.
 
- ![img](https://camo.githubusercontent.com/4326c3f603b828b61fd63d927acca2cfc152773f/68747470733a2f2f692e6779617a6f2e636f6d2f66353636643233363461663433646433613738633839323665643230346135312e706e67) 
+ ![img](https://camo.githubusercontent.com/4326c3f603b828b61fd63d927acca2cfc152773f/68747470733a2f2f692e6779617a6f2e636f6d2f66353636643233363461663433646433613738633839323665643230346135312e706e67)
 
-19. **[TensorSpace](https://tensorspace.org/)** :  TensorSpace is a neural network 3D visualization framework built by TensorFlow.js, Three.js and Tween.js. TensorSpace provides Layer APIs to build deep learning layers, load pre-trained models, and generate a 3D visualization in the browser. By applying TensorSpace API, it is more intuitive to visualize and understand any pre-trained models built by TensorFlow, Keras, TensorFlow.js, etc. 
+19. **[TensorSpace](https://tensorspace.org/)** :  TensorSpace is a neural network 3D visualization framework built by TensorFlow.js, Three.js and Tween.js. TensorSpace provides Layer APIs to build deep learning layers, load pre-trained models, and generate a 3D visualization in the browser. By applying TensorSpace API, it is more intuitive to visualize and understand any pre-trained models built by TensorFlow, Keras, TensorFlow.js, etc.
 
     **[Tutorial](https://www.freecodecamp.org/news/tensorspace-js-a-way-to-3d-visualize-neural-networks-in-browsers-2c0afd7648a8/)**
 
-     ![enter image description here](https://i.stack.imgur.com/ekF5v.png) 
+     ![enter image description here](https://i.stack.imgur.com/ekF5v.png)
 
-    ​	
+    ​
 
 20. **[Netscope CNN Analyzer](http://dgschwend.github.io/netscope/quickstart.html)**
 
- ![enter image description here](https://i.stack.imgur.com/VVDsg.png) 
+ ![enter image description here](https://i.stack.imgur.com/VVDsg.png)
 
-21. **[Monial](https://github.com/mlajtos/moniel)** 
+21. **[Monial](https://github.com/mlajtos/moniel)**
 
- Interactive Notation for Computational Graphs https://mlajtos.github.io/moniel/ 
+ Interactive Notation for Computational Graphs <https://mlajtos.github.io/moniel/>
 
- ![img](https://miro.medium.com/max/819/1*u6uIQF4xTVe-ylJnAPoIDg.png) 
+ ![img](https://miro.medium.com/max/819/1*u6uIQF4xTVe-ylJnAPoIDg.png)
 
 22. [**Texample**](http://www.texample.net/tikz/examples/neural-network/)
 
-![Neural Network](https://texample.net/media/tikz/examples/PNG/neural-network.png) 
-
+![Neural Network](https://texample.net/media/tikz/examples/PNG/neural-network.png)
 
 ```
 \documentclass{article}
@@ -231,10 +230,10 @@ Neataptic offers flexible neural networks; neurons and synapses can be removed w
 
 23. [**Quiver**](https://github.com/keplr-io/quiver)
 
- ![gzqll3](https://cloud.githubusercontent.com/assets/5866348/20253975/f3d56f14-a9e4-11e6-9693-9873a18df5d3.gif) 
+ ![gzqll3](https://cloud.githubusercontent.com/assets/5866348/20253975/f3d56f14-a9e4-11e6-9693-9873a18df5d3.gif)
 
-**References :**  
+**References :**
 
-1)  https://datascience.stackexchange.com/questions/12851/how-do-you-visualize-neural-network-architectures 
+1) <https://datascience.stackexchange.com/questions/12851/how-do-you-visualize-neural-network-architectures>
 
-2)   https://datascience.stackexchange.com/questions/2670/visualizing-deep-neural-network-training
+2) <https://datascience.stackexchange.com/questions/2670/visualizing-deep-neural-network-training>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Net2Vis automatically generates abstract visualizations for convolutional neural networks from Keras code.
 
-![](https://storage.googleapis.com/groundai-web-prod/media/users/user_299833/project_401171/images/application.png)
+![](https://viscom.publications.uni-ulm.de/api/uploads/4/baeuerle19net2vis-teaser-application.png)
 
 ## [visualkeras](https://github.com/paulgavrikov/visualkeras/)
 
@@ -183,7 +183,7 @@ These approaches are more oriented towards visualizing neural network operation,
 
 Neataptic offers flexible neural networks; neurons and synapses can be removed with a single line of code. No fixed architecture is required for neural networks to function at all. This flexibility allows networks to be shaped for your dataset through neuro-evolution, which is done using multiple threads.
 
-![img](https://camo.githubusercontent.com/4326c3f603b828b61fd63d927acca2cfc152773f/68747470733a2f2f692e6779617a6f2e636f6d2f66353636643233363461663433646433613738633839323665643230346135312e706e67)
+![img](https://i.gyazo.com/f566d2364af43dd3a78c8926ed204a51.png)
 
 ## [TensorSpace](https://tensorspace.org/)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
-## Tools to Design or Visualize Architecture of Neural Network
+# Tools to Design or Visualize Architecture of Neural Network
 
-1. [**Net2Vis**](https://viscom.net2vis.uni-ulm.de/OG1Br2BAkYSwwrV6CADl4X5EfErFjUzvuUwXWDdLbdsIXNhb9L): Net2Vis automatically generates abstract visualizations for convolutional neural networks from Keras code.
+## [Net2Vis](https://viscom.net2vis.uni-ulm.de/OG1Br2BAkYSwwrV6CADl4X5EfErFjUzvuUwXWDdLbdsIXNhb9L)
+
+Net2Vis automatically generates abstract visualizations for convolutional neural networks from Keras code.
 
 ![](https://storage.googleapis.com/groundai-web-prod/media/users/user_299833/project_401171/images/application.png)
 
-2. [**visualkeras**](https://github.com/paulgavrikov/visualkeras/) :  Visualkeras is a Python package to help visualize Keras (either standalone or included in tensorflow) neural network architectures. It allows easy styling to fit most needs. As of now it supports layered style architecture generation which is great for CNNs (Convolutional Neural Networks) and a grap style architecture.
+## [visualkeras](https://github.com/paulgavrikov/visualkeras/)
+
+Visualkeras is a Python package to help visualize Keras (either standalone or included in tensorflow) neural network architectures. It allows easy styling to fit most needs. As of now it supports layered style architecture generation which is great for CNNs (Convolutional Neural Networks) and a grap style architecture.
 
 ```python
 import visualkeras
@@ -18,47 +22,57 @@ visualkeras.layered_view(model, to_file='output.png').show() # write and show
 visualkeras.layered_view(model)
 ```
 
-![](https://github.com/paulgavrikov/visualkeras/raw/master/figures/vgg16.png)
+![Visualization of the VGG16 neural network with stacked layers of decreasing size.](https://github.com/paulgavrikov/visualkeras/raw/master/figures/vgg16.png)
 
-3. [**draw_convnet**](https://github.com/gwding/draw_convnet) : Python script for illustrating Convolutional Neural Network (ConvNet)
+## [draw_convnet](https://github.com/gwding/draw_convnet)
 
- ![img](https://raw.githubusercontent.com/gwding/draw_convnet/master/convnet_fig.png)
+Python script for illustrating Convolutional Neural Network (ConvNet)
 
-4. [**NNSVG**](http://alexlenail.me/NN-SVG/LeNet.html)
+![img](https://raw.githubusercontent.com/gwding/draw_convnet/master/convnet_fig.png)
 
- ![AlexNet style](https://i.stack.imgur.com/Q0xOe.png)
+## [NNSVG](http://alexlenail.me/NN-SVG/LeNet.html)
 
- ![enter image description here](https://i.stack.imgur.com/K9lmg.png)
+![AlexNet style](https://i.stack.imgur.com/Q0xOe.png)
 
- ![enter image description here](https://i.stack.imgur.com/DlJ8J.png)
+![enter image description here](https://i.stack.imgur.com/K9lmg.png)
 
-5. **[PlotNeuralNet](https://github.com/HarisIqbal88/PlotNeuralNet)**  : Latex code for drawing neural networks for reports and presentation. Have a look into examples to see how they are made. Additionally, lets consolidate any improvements that you make and fix any bugs to help more people with this code.
+![enter image description here](https://i.stack.imgur.com/DlJ8J.png)
 
- ![img](https://user-images.githubusercontent.com/17570785/50308846-c2231880-049c-11e9-8763-3daa1024de78.png)
+## [PlotNeuralNet](https://github.com/HarisIqbal88/PlotNeuralNet)
 
- ![img](https://user-images.githubusercontent.com/17570785/50308873-e2eb6e00-049c-11e9-9587-9da6bdec011b.png)
+Latex code for drawing neural networks for reports and presentation. Have a look into examples to see how they are made. Additionally, lets consolidate any improvements that you make and fix any bugs to help more people with this code.
 
-6. **[Tensorboard](https://www.tensorflow.org/tensorboard/graphs)** -  TensorBoard’s **Graphs dashboard** is a powerful tool for examining your TensorFlow model.
+![img](https://user-images.githubusercontent.com/17570785/50308846-c2231880-049c-11e9-8763-3daa1024de78.png)
 
- ![enter image description here](https://i.stack.imgur.com/zJHpV.png)
+![img](https://user-images.githubusercontent.com/17570785/50308873-e2eb6e00-049c-11e9-9587-9da6bdec011b.png)
 
-7. **[Caffe](https://github.com/BVLC/caffe/blob/master/python/caffe/draw.py)** -  In Caffe you can use [caffe/draw.py](https://github.com/BVLC/caffe/blob/master/python/caffe/draw.py) to draw the NetParameter protobuffer:
+## [Tensorboard](https://www.tensorflow.org/tensorboard/graphs)
 
- ![enter image description here](https://i.stack.imgur.com/5Z1Cb.png)
+TensorBoard’s **Graphs dashboard** is a powerful tool for examining your TensorFlow model.
 
-8. **[Matlab](http://www.mathworks.com/help/nnet/ref/view.html)**
+![enter image description here](https://i.stack.imgur.com/zJHpV.png)
 
- ![enter image description here](https://i.stack.imgur.com/rPpfa.png)
+## [Caffe](https://github.com/BVLC/caffe/blob/master/python/caffe/draw.py)
 
-9. [**Keras.js**](https://transcranial.github.io/keras-js/#/inception-v3)
+In Caffe you can use [caffe/draw.py](https://github.com/BVLC/caffe/blob/master/python/caffe/draw.py) to draw the NetParameter protobuffer:
 
- ![enter image description here](https://i.stack.imgur.com/vEfTv.png)
+![enter image description here](https://i.stack.imgur.com/5Z1Cb.png)
 
-9. **[keras-sequential-ascii](https://github.com/stared/keras-sequential-ascii/)** -  A library for [Keras](https://keras.io/) for investigating architectures and parameters of sequential models.
+## [Matlab](http://www.mathworks.com/help/nnet/ref/view.html)
 
-**VGG 16 Architecture**
+![enter image description here](https://i.stack.imgur.com/rPpfa.png)
 
-```
+## [Keras.js](https://transcranial.github.io/keras-js/#/inception-v3)
+
+![enter image description here](https://i.stack.imgur.com/vEfTv.png)
+
+## [keras-sequential-ascii](https://github.com/stared/keras-sequential-ascii/)
+
+A library for [Keras](https://keras.io/) for investigating architectures and parameters of sequential models.
+
+### VGG 16 Architecture
+
+```text
            OPERATION           DATA DIMENSIONS   WEIGHTS(N)   WEIGHTS(%)
 
               Input   #####      3  224  224
@@ -110,76 +124,90 @@ visualkeras.layered_view(model)
             softmax   #####        1000
 ```
 
-10. **[Netron](https://github.com/lutzroeder/Netron)**
+## [Netron](https://github.com/lutzroeder/Netron)
 
- ![screenshot.png](https://github.com/lutzroeder/netron/raw/main/.github/screenshot.png)
+![screenshot.png](https://github.com/lutzroeder/netron/raw/main/.github/screenshot.png)
 
-11. **[DotNet](https://github.com/martisak/dotnets)**
+## [DotNet](https://github.com/martisak/dotnets)
 
- ![Simple net](https://github.com/martisak/dotnets/raw/master/test.png)
+![Simple net](https://github.com/martisak/dotnets/raw/master/test.png)
 
-12. [**Graphviz**](http://www.graphviz.org/) : **[Tutorial](https://tgmstat.wordpress.com/2013/06/12/draw-neural-network-diagrams-graphviz/)**
+## [Graphviz](http://www.graphviz.org/)
 
- ![img](https://tgmstat.files.wordpress.com/2013/05/multiclass_neural_network_example.png)
+**[Tutorial](https://tgmstat.wordpress.com/2013/06/12/draw-neural-network-diagrams-graphviz/)**
 
-13. **[Keras Visualization](https://keras.io/visualization/)** -  The [keras.utils.vis_utils module](https://keras.io/visualization/) provides utility functions to plot a Keras model (using graphviz)
+![img](https://tgmstat.files.wordpress.com/2013/05/multiclass_neural_network_example.png)
 
- ![enter image description here](https://i.stack.imgur.com/o17GY.png)
+## [Keras Visualization](https://keras.io/visualization/)
 
-14. **[Conx](https://conx.readthedocs.io/en/latest/index.html)** -  The Python package `conx` can visualize networks with activations with the function `net.picture()` to produce SVG, PNG, or PIL Images like this:
+The [keras.utils.vis_utils module](https://keras.io/visualization/) provides utility functions to plot a Keras model (using graphviz)
 
- ![enter image description here](https://i.stack.imgur.com/nhHjO.png)
+![enter image description here](https://i.stack.imgur.com/o17GY.png)
 
-15. **[ENNUI](https://math.mit.edu/ennui/)** -  Working on a drag-and-drop neural network visualizer (and more). Here's an example of a visualization for a LeNet-like architecture.
+## [Conx](https://conx.readthedocs.io/en/latest/index.html)
 
- ![A visualization of a LeNet-like architecture](https://i.stack.imgur.com/pRLeG.png)
+The Python package `conx` can visualize networks with activations with the function `net.picture()` to produce SVG, PNG, or PIL Images like this:
 
-16. **NNet - R Package** - **[Tutorial](https://beckmw.wordpress.com/2013/03/04/visualizing-neural-networks-from-the-nnet-package/)**
+![enter image description here](https://i.stack.imgur.com/nhHjO.png)
 
-```
+## [ENNUI](https://math.mit.edu/ennui/)
+
+Working on a drag-and-drop neural network visualizer (and more). Here's an example of a visualization for a LeNet-like architecture.
+
+![A visualization of a LeNet-like architecture](https://i.stack.imgur.com/pRLeG.png)
+
+## NNet - R Package
+
+**[Tutorial](https://beckmw.wordpress.com/2013/03/04/visualizing-neural-networks-from-the-nnet-package/)**
+
+```R
 data(infert, package="datasets")
 plot(neuralnet(case~parity+induced+spontaneous, infert))
 ```
 
-[![neuralnet](https://i.stack.imgur.com/yyftd.png)](https://
+![neuralnet](https://i.stack.imgur.com/yyftd.png)
 
-17. **[GraphCore](https://www.graphcore.ai/posts/what-does-machine-learning-look-like)** -  These approaches are more oriented towards visualizing neural network operation, however, NN architecture is also somewhat visible on the resulting diagrams.
+## [GraphCore](https://www.graphcore.ai/posts/what-does-machine-learning-look-like)
 
-**AlexNet**
+These approaches are more oriented towards visualizing neural network operation, however, NN architecture is also somewhat visible on the resulting diagrams.
 
- ![alexnet_label logo.jpg](https://www.graphcore.ai/hubfs/images/alexnet_label%20logo.jpg)
+### AlexNet
 
- **ResNet50**![resnet50_label_logo.jpg](https://www.graphcore.ai/hubfs/images/resnet50_label_logo.jpg)
+![alexnet_label logo.jpg](https://www.graphcore.ai/hubfs/images/alexnet_label%20logo.jpg)
 
-18. [**Neataptic**](https://wagenaartje.github.io/neataptic/ )
+### ResNet50
+
+![resnet50_label_logo.jpg](https://www.graphcore.ai/hubfs/images/resnet50_label_logo.jpg)
+
+## [Neataptic](https://wagenaartje.github.io/neataptic/)
 
 Neataptic offers flexible neural networks; neurons and synapses can be removed with a single line of code. No fixed architecture is required for neural networks to function at all. This flexibility allows networks to be shaped for your dataset through neuro-evolution, which is done using multiple threads.
 
- ![img](https://camo.githubusercontent.com/4326c3f603b828b61fd63d927acca2cfc152773f/68747470733a2f2f692e6779617a6f2e636f6d2f66353636643233363461663433646433613738633839323665643230346135312e706e67)
+![img](https://camo.githubusercontent.com/4326c3f603b828b61fd63d927acca2cfc152773f/68747470733a2f2f692e6779617a6f2e636f6d2f66353636643233363461663433646433613738633839323665643230346135312e706e67)
 
-19. **[TensorSpace](https://tensorspace.org/)** :  TensorSpace is a neural network 3D visualization framework built by TensorFlow.js, Three.js and Tween.js. TensorSpace provides Layer APIs to build deep learning layers, load pre-trained models, and generate a 3D visualization in the browser. By applying TensorSpace API, it is more intuitive to visualize and understand any pre-trained models built by TensorFlow, Keras, TensorFlow.js, etc.
+## [TensorSpace](https://tensorspace.org/)
 
-    **[Tutorial](https://www.freecodecamp.org/news/tensorspace-js-a-way-to-3d-visualize-neural-networks-in-browsers-2c0afd7648a8/)**
+TensorSpace is a neural network 3D visualization framework built by TensorFlow.js, Three.js and Tween.js. TensorSpace provides Layer APIs to build deep learning layers, load pre-trained models, and generate a 3D visualization in the browser. By applying TensorSpace API, it is more intuitive to visualize and understand any pre-trained models built by TensorFlow, Keras, TensorFlow.js, etc.
 
-     ![enter image description here](https://i.stack.imgur.com/ekF5v.png)
+**[Tutorial](https://www.freecodecamp.org/news/tensorspace-js-a-way-to-3d-visualize-neural-networks-in-browsers-2c0afd7648a8/)**
 
-    ​
+![enter image description here](https://i.stack.imgur.com/ekF5v.png)
 
-20. **[Netscope CNN Analyzer](http://dgschwend.github.io/netscope/quickstart.html)**
+## [Netscope CNN Analyzer](http://dgschwend.github.io/netscope/quickstart.html)
 
- ![enter image description here](https://i.stack.imgur.com/VVDsg.png)
+![enter image description here](https://i.stack.imgur.com/VVDsg.png)
 
-21. **[Monial](https://github.com/mlajtos/moniel)**
+## [Monial](https://github.com/mlajtos/moniel)
 
- Interactive Notation for Computational Graphs <https://mlajtos.github.io/moniel/>
+Interactive Notation for Computational Graphs <https://mlajtos.github.io/moniel/>
 
- ![img](https://miro.medium.com/max/819/1*u6uIQF4xTVe-ylJnAPoIDg.png)
+![img](https://miro.medium.com/max/819/1*u6uIQF4xTVe-ylJnAPoIDg.png)
 
-22. [**Texample**](http://www.texample.net/tikz/examples/neural-network/)
+## [Texample](http://www.texample.net/tikz/examples/neural-network/)
 
 ![Neural Network](https://texample.net/media/tikz/examples/PNG/neural-network.png)
 
-```
+```latex
 \documentclass{article}
 
 \usepackage{tikz}
@@ -228,11 +256,11 @@ Neataptic offers flexible neural networks; neurons and synapses can be removed w
 \end{document}
 ```
 
-23. [**Quiver**](https://github.com/keplr-io/quiver)
+## [Quiver](https://github.com/keplr-io/quiver)
 
- ![gzqll3](https://cloud.githubusercontent.com/assets/5866348/20253975/f3d56f14-a9e4-11e6-9693-9873a18df5d3.gif)
+![gzqll3](https://cloud.githubusercontent.com/assets/5866348/20253975/f3d56f14-a9e4-11e6-9693-9873a18df5d3.gif)
 
-**References :**
+**References:**
 
 1) <https://datascience.stackexchange.com/questions/12851/how-do-you-visualize-neural-network-architectures>
 


### PR DESCRIPTION
I replaced the numbered list format with sections and sub-sections.  Also found two of the missing images and replaced them.  (https://github.com/ashishpatel26/Tools-to-Design-or-Visualize-Architecture-of-Neural-Network/issues/12)

On GitHub, there are still other images that are missing:

![image](https://github.com/user-attachments/assets/74bddf9c-fe2b-4520-9832-54b530cabcf8)

but they work in Typora on my local machine:

![image](https://github.com/user-attachments/assets/9e9a74c0-8822-4f65-82b3-e1380735f329)

so it's some issue with the GitHub image URLs.